### PR TITLE
Add SSL support (as well as merge ifixit-production)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "nodejs/vendor/connect-assetmanager"]
-	path = nodejs/vendor/connect-assetmanager
-	url = git://github.com/danielbeardsley/connect-assetmanager.git
-
 [submodule "nodejs/vendor/express-resource"]
 	path = nodejs/vendor/express-resource
 	url = git://github.com/Wompt/express-resource.git

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,7 +13,8 @@ set :copy_exclude, [".git"]
 set :monit_config_location, "/etc/monit/"
 
 # Node settings
-set :node_path, "/usr/bin/node"
+set :node_path, "/usr/local/bin/node"
+set :npm_path, "/usr/local/bin/npm"
 
 default_run_options[:pty] = true
 

--- a/config/gems.rb
+++ b/config/gems.rb
@@ -1,6 +1,7 @@
 namespace :deploy do
 	namespace :gems do
-		after 'deploy:cold', 'deploy:gems:install'
+		# Disable oauth authentication for now
+		# after 'deploy:cold', 'deploy:gems:install'
 
 		desc "Deploy and install missing ruby gem dependencies on the server"
 		task :default, :roles => :app do

--- a/config/npm.rb
+++ b/config/npm.rb
@@ -12,7 +12,7 @@ namespace :deploy do
 		desc "Install missing npm dependencies on the server"
 		task :install, :roles => :app do
 			run "mkdir -p #{shared_path}/node_modules"
-			run "cd #{current_path}/nodejs && npm install "
+			run "cd #{current_path}/nodejs && #{npm_path} install "
 		end
 		
 		desc "Create the necessary symlinks for npm"

--- a/config/tasks.rb
+++ b/config/tasks.rb
@@ -21,7 +21,7 @@ namespace :deploy do
   end
   
   def apps
-    ["#{env_prefix}wompt_auth", "#{env_prefix}wompt"]
+    ["#{env_prefix}wompt"]
   end
   
   def env_prefix

--- a/nodejs/dependencies.js
+++ b/nodejs/dependencies.js
@@ -8,5 +8,5 @@ module.exports = {
 	lingo: require('lingo'),
 	socketio: require('socket.io'),
 	expressResource: require("./vendor/express-resource"),
-	connectAssetManager: require('./vendor/connect-assetmanager')
+	connectAssetManager: require('connect-assetmanager')
 }

--- a/nodejs/environment/defaults.js
+++ b/nodejs/environment/defaults.js
@@ -80,6 +80,15 @@ module.exports = {
 		noFacebook:false
 	}
 	
+	// Allow access to user profile pages
+	, userProfiles: true
+
+	// Allow access to the home page
+	, homePage: true
+
+	// Allow access to the public non-account namespaces (/chat, /mod, ...)
+	, publicNamespaces: true
+
 	, redirectWww: false
 	, redirectWwwToPort: 16867
 

--- a/nodejs/environment/defaults.js
+++ b/nodejs/environment/defaults.js
@@ -82,4 +82,6 @@ module.exports = {
 	
 	, redirectWww: false
 	, redirectWwwToPort: 16867
+
+	, ipWhitelist: null
 }

--- a/nodejs/environment/defaults.js
+++ b/nodejs/environment/defaults.js
@@ -6,6 +6,9 @@ deploy_root = path.normalize(root + '/..');
 
 module.exports = {
 	  port: 8001
+	, ssl: false 
+	, key: ''
+	, cert: ''
 	, public_dir: root + '/public'
 	, db_name: 'wompt_dev'
 	, root: root

--- a/nodejs/environment/production.js
+++ b/nodejs/environment/production.js
@@ -28,6 +28,14 @@ module.exports = {
 			'log level': 1
 		}
 	}
+	// Allow access to user profile pages
+	, userProfiles: false
+	// Allow access to the home page
+	, homePage: false
+
+	// Allow access to the public non-account namespaces (/chat, /mod, ...)
+	, publicNamespaces: false
+
 	, redirectWww	: true
 	, ipWhitelist: ['72.29.166.163']
 }

--- a/nodejs/environment/production.js
+++ b/nodejs/environment/production.js
@@ -29,4 +29,5 @@ module.exports = {
 		}
 	}
 	, redirectWww	: true
+	, ipWhitelist: ['72.29.166.163']
 }

--- a/nodejs/environment/production.js
+++ b/nodejs/environment/production.js
@@ -11,7 +11,7 @@ module.exports = {
 
 	, hoptoad: {
 		  apiKey: '2d12a5a4e55714b1d7a3fbae31c5e0ae'
-		, reportErrors: true
+		, reportErrors: false
 	}
 	, logs: {
 		root: path.normalize(shared + '/log')

--- a/nodejs/lib/app.js
+++ b/nodejs/lib/app.js
@@ -1,7 +1,8 @@
-var http   = require("http"),
+var http   = require("https"),
     url    = require("url"),
     wompt  = require("./includes"),
     util   = require('util'),
+    fs     = require('fs'),
     logger = wompt.logger,
     SocketIO= wompt.SocketIO,
     assetManager = require('./asset_manager'),
@@ -12,6 +13,10 @@ function App(options){
 	var self = this;
 	
 	this.config = options.config;
+	this.credentials = {
+		key: this.config.ssl ? fs.readFileSync(this.config.key) : ''
+		, cert: this.config.ssl ? fs.readFileSync(this.config.cert) : ''
+	};
 	this.pretty_print_config();
 	this.meta_users = new wompt.MetaUserManager();
 	this.accountManager = new wompt.AccountManager();
@@ -71,7 +76,7 @@ App.prototype = {
 
 	create_express_server:function(){
 		var config = this.config;
-		var exp = express.createServer();
+		var exp = config.ssl ? express.createServer(this.credentials) : express.createServer();
 		var me = this;
 		
 		exp.configure(function(){

--- a/nodejs/lib/app.js
+++ b/nodejs/lib/app.js
@@ -134,8 +134,9 @@ App.prototype = {
 			,'/contact_us'
 		]);
 		
-		exp.get("/", landingPage);
-
+		if (this.config.homePage) {
+			exp.get("/", landingPage);
+		}
 
 		exp.post("/", function(req, res){
 			wompt.Auth.get_or_set_token(req, res);

--- a/nodejs/lib/authentication.js
+++ b/nodejs/lib/authentication.js
@@ -110,10 +110,16 @@ function Auth(config){
 	
 	// Gives 404 errors for non admins
 	this.blockNonAdmins = function(req, res, next){
-		if(req.user && req.user.is_admin())
+		if(isFromAdmin(req))
 			next();
 		else
 			next(new wompt.errors.NotFound());
+	}
+
+	this.isFromAdmin = isFromAdmin;
+	function isFromAdmin(req) {
+		return (req.user && req.user.is_admin()) ||
+		(config.ipWhitelist && config.ipWhitelist.indexOf(req.connection.remoteAddress) !== -1);
 	}
 	
 	this.start_session = function(res, user){

--- a/nodejs/lib/authentication.js
+++ b/nodejs/lib/authentication.js
@@ -147,6 +147,16 @@ function Auth(config){
 			user.save(callback);
 		} else callback();
 	}
+
+	// Give the response a session that is associated with this user
+	// so they are effectively signed in for future requests
+	this.adopt_existing_session = function (res, user) {
+		if (user.sessions.length > 0) {
+			this.set_cookie(res, user.sessions[0].token);
+		} else {
+		   this.start_session(res, user);
+		}
+	}
 		
 		
 	this.clear_token = function(response){

--- a/nodejs/lib/controllers/accounts.js
+++ b/nodejs/lib/controllers/accounts.js
@@ -173,7 +173,8 @@ function AccountsController(app){
 	}
 	
 	function allowOwnersAndAdmins(req, res, next){
-		if(req.user && (req.user.is_admin() || req.account.owner_ids.indexOf(req.user.id) >= 0))
+		if(wompt.Auth.isFromAdmin(req) ||
+		(req.user && req.account.owner_ids.indexOf(req.user.id) >= 0))
 			next();
 		else
 			next(new wompt.errors.NotFound());

--- a/nodejs/lib/controllers/namespace.js
+++ b/nodejs/lib/controllers/namespace.js
@@ -32,7 +32,9 @@ function NamespaceController(app){
 		}
 		
 		// Public namespaces are accesible at /namespace
-		express.get("/:namespace/*", createNamespaceFilter('public'));
+		if (wompt.env.publicNamespaces) {
+			express.get("/:namespace/*", createNamespaceFilter('public'));
+		}
 
 		// Namespaces owned by accounts are assessible at /a/namespace
 		express.get("/a/:namespace/*", createNamespaceFilter('account')); 

--- a/nodejs/lib/controllers/profile.js
+++ b/nodejs/lib/controllers/profile.js
@@ -6,6 +6,8 @@ function ProfileController(app){
 	self = this;
 	
 	this.register = function(){
+		if (!wompt.env.userProfiles)
+			return;
 		express.get("/users/:id", renderProfile);
 		express.post("/profile", changeSettings);
 		express.get("/profile", ownProfilePage);		

--- a/nodejs/lib/models/user.js
+++ b/nodejs/lib/models/user.js
@@ -72,8 +72,8 @@ User.method({
 	
 	is_admin: function(){
 		return (this.email in {
-			'dbeardsl@gmail.com': true,
-			'abtinf@gmail.com': true
+			'daniel@ifixit.com': true,
+			'kyle@ifixit.com': true
 		});
 	}
 });

--- a/nodejs/lib/parameter_authentication.js
+++ b/nodejs/lib/parameter_authentication.js
@@ -108,6 +108,11 @@ function loadUserBasedOnQueryParam(req, res, next){
 	function proceede(err, user) {
 		if (user) {
 			req.user = user;
+			var email = req.query.email;
+			if (email && user.email != email) {
+				user.email = email;
+				user.save();
+			}
 			wompt.Auth.adopt_existing_session(res, user);
 		}
 
@@ -120,7 +125,8 @@ function createUserFromQueryParams(req, callback){
 	var user = new wompt.User({
 		account_id: req.account.id,
 		account_user_id: q.user_id,
-		name: q.user_name
+		name: q.user_name,
+		email: q.email
 	});
 	
 	user.save(callback);

--- a/nodejs/lib/parameter_authentication.js
+++ b/nodejs/lib/parameter_authentication.js
@@ -89,14 +89,9 @@ function loadUserBasedOnQueryParam(req, res, next){
 			wompt.User.findOne({account_id: req.account.id, account_user_id: req.query.user_id},
 			function(err, user){
 				if(user){
-					req.user = user;
-					next();
+					proceede(err, user);
 				}else{
-					createUserFromQueryParams(req, function(err, user){
-						if(user)
-							req.user = user;
-						return next(err);				
-					});
+					createUserFromQueryParams(req, proceede);
 				}
 			})
 		} else if(req.query.anonymous === '1') { // no user_id parameter, check for anonymous=
@@ -109,6 +104,15 @@ function loadUserBasedOnQueryParam(req, res, next){
 	// see Util.preStackMiddleware
 	else
 		next(null, 'break');
+
+	function proceede(err, user) {
+		if (user) {
+			req.user = user;
+			wompt.Auth.adopt_existing_session(res, user);
+		}
+
+		return next(err);
+	}
 }
 
 function createUserFromQueryParams(req, callback){

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -19,6 +19,7 @@
 		"lingo": "0.0.4",
 		"socket.io" : "~0.8.7",
 		"connect-assetmanager-handlers" : "~0.0.17",
+		"connect-assetmanager" : "~0.0.28",
 		"request" : "~0.10.0",
 		"airbrake" : "~0.2.4"
 	},

--- a/nodejs/public/fb_cross_domain.html
+++ b/nodejs/public/fb_cross_domain.html
@@ -1,1 +1,1 @@
-<script src="http://connect.facebook.net/en_US/all.js"></script>
+<script src="//connect.facebook.net/en_US/all.js"></script>

--- a/nodejs/public/js/ui.messages.js
+++ b/nodejs/public/js/ui.messages.js
@@ -41,11 +41,11 @@ UI.once('init', function(){
 		if(Util.Text.linkifyTest(text)){
 			//escape [<, >, ', ", &] so we don't include any nasty html tags
 			text = text
+          .replace(/&/g, '&amp;')
           .replace(/'/g, '&#39;')
           .replace(/"/g, '&quot;')
-          .replace(/&/g, '&amp;')
           .replace(/</g, '&lt;')
-          .replace(/>/g,'&gt;');
+          .replace(/>/g, '&gt;');
 			el.html(Util.Text.linkify(text));
 		}
 		else

--- a/nodejs/views/layouts/iframe.jade
+++ b/nodejs/views/layouts/iframe.jade
@@ -21,5 +21,5 @@ html("xmlns\u003Afb"="http://www.facebook.com/2008/fbml", xmlns="http://www.w3.o
 				UI.input = UI.input || {};
 				UI.input.disableAutoExpand = true;
 		- if(w.channel && !w.ui.hideSocialLinks && !w.config.flags.noFacebook)
-			script(type='text/javascript', src='http://connect.facebook.net/en_US/all.js#appId=181725458505189&xfbml=1',async='true')
+			script(type='text/javascript', src='//connect.facebook.net/en_US/all.js#appId=181725458505189&xfbml=1',async='true')
 		!=partial('shared/_ga')

--- a/nodejs/views/layouts/standard.jade
+++ b/nodejs/views/layouts/standard.jade
@@ -20,5 +20,5 @@ html("xmlns\u003Afb"="http://www.facebook.com/2008/fbml", xmlns="http://www.w3.o
 				script(src="/socket.io/socket.io.js")
 			!{assetHelpers.assetGroupTag(w.page_js, w.user && w.user.doc)}
 		- if(w.channel && !w.config.flags.noFacebook)
-			script(type='text/javascript', src='http://connect.facebook.net/en_US/all.js#appId=181725458505189&xfbml=1',async='true')
+			script(type='text/javascript', src='//connect.facebook.net/en_US/all.js#appId=181725458505189&xfbml=1',async='true')
 		!=partial('shared/_ga')

--- a/wompt.conf.example
+++ b/wompt.conf.example
@@ -7,7 +7,7 @@ set :user, "ubuntu"
 # The servers the application will run on
 role :app, "yourserver.com"
 # The git repo that should be cloned when deploying
-set :repository, "http://github.com/yourforkof/wompt.com"
+set :repository, "https://github.com/yourforkof/wompt.com"
 set :use_sudo, true
 
 # Override or add any tasks here that you need to,


### PR DESCRIPTION
In addition to the previous changes (from ifixit-production), we now support HTTPS.

Now, in the environment configuration you can specify:

```
, ssl: true
, key: '/path/to/key.pem'
, cert: '/path/to/cert.pem'
```

Toggling `ssl` will enable and disable ssl regardless of whether key/cert files have been specified.

In anticipation for https being enabled,
this also removes the strict protocol for scripts in a few of the templates
and layout partials (changing from `http://...` to `//...`, as it is
supported in a fair amount of browsers these days).
